### PR TITLE
problem fixed - add response_id to msg with zero sources

### DIFF
--- a/semant_demo_frontend/src/pages/RagPage.vue
+++ b/semant_demo_frontend/src/pages/RagPage.vue
@@ -356,7 +356,8 @@ const sendMessage = async () => {
       messages.value.push({
         sender: 'AI',
         text: 'Sorry we have no information about this topick.',
-        sources: []
+        sources: [],
+        response_id: crypto.randomUUID()
       })
       return
     }


### PR DESCRIPTION
### Goal
- Fix a bug where feedback could not be submitted for RAG responses without sources

### Solution
- The issue occurred for responses with zero sources, where a fallback message was created on the frontend without a response_id
- Added automatic response_id generation for these fallback messages to ensure feedback submission works correctly