### PR TITLE
69 enable named vectors in weaviate db

### DIFF
--- a/semant_demo_backend/semant_demo/config.py
+++ b/semant_demo_backend/semant_demo/config.py
@@ -89,7 +89,7 @@ class Config:
         default_mapping = {
             "nomic_embed_text_v2_moe": {
                 "provider": EmbeddingProvider.ollama.value,
-                "model": os.getenv("OLLAMA_NOMIC_EMBEDDING_MODEL", "nomic-embed-text:v2-moe"),
+                "model": os.getenv("OLLAMA_NOMIC_EMBEDDING_MODEL", "nomic-embed-text-v2-moe:latest"),
                 "base_url": self.OLLAMA_URLS[0],
             },
             "qwen3_embedding_4b": {
@@ -99,10 +99,9 @@ class Config:
                 "api_key": self.OPENROUTER_API_KEY,
             },
             "qwen3_embedding_0_6b": {
-                "provider": EmbeddingProvider.openrouter.value,
-                "model": os.getenv("OPENROUTER_QWEN3_EMBEDDING_0_6B_MODEL", "qwen/qwen3-embedding-0.6b"),
-                "base_url": self.OPENROUTER_API_URL,
-                "api_key": self.OPENROUTER_API_KEY,
+                "provider": EmbeddingProvider.ollama.value,
+                "model": os.getenv("OLLAMA_QWEN3_EMBEDDING_0_6B_MODEL", "qwen3-embedding-0.6b:latest"),
+                "base_url": self.OLLAMA_URLS[0],
             },
         }
 

--- a/semant_demo_backend/semant_demo/config.py
+++ b/semant_demo_backend/semant_demo/config.py
@@ -1,15 +1,23 @@
+import json
 import os
 from pathlib import Path
-from semant_demo.schemas import CollectionNames
+from semant_demo.schemas import CollectionNames, EmbeddingProvider
 
 
 TRUE_VALUES = {"true", "1"}
 SCRIPT_PATH = Path(__file__).parent
+DEFAULT_CHUNK_VECTORS = [
+    "nomic_embed_text_v2_moe",
+    "qwen3_embedding_4b",
+    "qwen3_embedding_0_6b",
+]
 
 class Config:
     def __init__(self):
         self.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
         self.OPENAI_API_URL = os.getenv("OPENAI_API_URL", "https://openrouter.ai/api/v1")
+        self.OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", self.OPENAI_API_KEY)
+        self.OPENROUTER_API_URL = os.getenv("OPENROUTER_API_URL", self.OPENAI_API_URL)
         
         self.WEAVIATE_HOST = os.getenv("WEAVIATE_HOST", "localhost")
         self.WEAVIATE_REST_PORT = os.getenv("WEAVIATE_REST_PORT", 8080)
@@ -30,6 +38,19 @@ class Config:
         self.OLLAMA_URLS = os.getenv("OLLAMA_URLS", "http://localhost:11434").split(",")
         self.OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "gemma3:12b")
         self.SEARCH_SUMMARIZER_CONFIG = os.getenv("SEARCH_SUMMARIZER_CONFIG", str(SCRIPT_PATH / "configs" / "search_summarizer.yaml"))
+
+        self.AVAILABLE_CHUNK_VECTORS = os.getenv(
+            "AVAILABLE_CHUNK_VECTORS",
+            ",".join(DEFAULT_CHUNK_VECTORS),
+        )
+        self.AVAILABLE_CHUNK_VECTORS = [
+            vector_name.strip()
+            for vector_name in self.AVAILABLE_CHUNK_VECTORS.split(",")
+            if vector_name.strip()
+        ]
+        self.DEFAULT_CHUNK_VECTOR = os.getenv("DEFAULT_CHUNK_VECTOR", "nomic_embed_text_v2_moe")
+        self.CHUNK_VECTOR_EMBEDDINGS = self._load_chunk_vector_embeddings()
+        self.validate_chunk_vector(self.DEFAULT_CHUNK_VECTOR)
 
         self.GOOGLE_MODEL = os.getenv("GOOGLE_MODEL", "gemini-2.5-pro")
         self.OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
@@ -55,7 +76,7 @@ class Config:
         self.RAG_CONFIGS_PATH = os.getenv("RAG_CONFIGS_PATH", default_config_path)
 
         self.collectionNames = CollectionNames(
-            chunks_collection_name = "Chunks",
+            chunks_collection_name = os.getenv("CHUNKS_COLLECTION_NAME", "Chunks_test_multivector"),
             tag_collection_name = "Tag",
             user_collection_name = "UserCollection",
             document_collection_name= "Documents",
@@ -63,5 +84,50 @@ class Config:
             user_collection_link_name = "userCollection",
             tag_to_user_collection_link_name= "tagToUserCollection",
         )
+
+    def _load_chunk_vector_embeddings(self) -> dict[str, dict[str, str]]:
+        default_mapping = {
+            "nomic_embed_text_v2_moe": {
+                "provider": EmbeddingProvider.ollama.value,
+                "model": os.getenv("OLLAMA_NOMIC_EMBEDDING_MODEL", "nomic-embed-text:v2-moe"),
+                "base_url": self.OLLAMA_URLS[0],
+            },
+            "qwen3_embedding_4b": {
+                "provider": EmbeddingProvider.openrouter.value,
+                "model": os.getenv("OPENROUTER_QWEN3_EMBEDDING_4B_MODEL", "qwen/qwen3-embedding-4b"),
+                "base_url": self.OPENROUTER_API_URL,
+                "api_key": self.OPENROUTER_API_KEY,
+            },
+            "qwen3_embedding_0_6b": {
+                "provider": EmbeddingProvider.openrouter.value,
+                "model": os.getenv("OPENROUTER_QWEN3_EMBEDDING_0_6B_MODEL", "qwen/qwen3-embedding-0.6b"),
+                "base_url": self.OPENROUTER_API_URL,
+                "api_key": self.OPENROUTER_API_KEY,
+            },
+        }
+
+        raw_mapping = os.getenv("CHUNK_VECTOR_EMBEDDINGS")
+        if raw_mapping is None:
+            return default_mapping
+
+        configured_mapping = json.loads(raw_mapping)
+        return {**default_mapping, **configured_mapping}
+
+    def validate_chunk_vector(self, vector_name: str) -> str:
+        if vector_name not in self.AVAILABLE_CHUNK_VECTORS:
+            raise ValueError(
+                f"Unknown chunk vector '{vector_name}'. "
+                f"Available vectors: {', '.join(self.AVAILABLE_CHUNK_VECTORS)}"
+            )
+        if vector_name not in self.CHUNK_VECTOR_EMBEDDINGS:
+            raise ValueError(f"Missing embedding configuration for chunk vector '{vector_name}'")
+        return vector_name
+
+    def resolve_chunk_vector(self, vector_name: str | None = None) -> str:
+        return self.validate_chunk_vector(vector_name or self.DEFAULT_CHUNK_VECTOR)
+
+    def get_chunk_vector_embedding_config(self, vector_name: str | None = None) -> dict[str, str]:
+        resolved_vector = self.resolve_chunk_vector(vector_name)
+        return self.CHUNK_VECTOR_EMBEDDINGS[resolved_vector]
 
 config = Config()

--- a/semant_demo_backend/semant_demo/config.py
+++ b/semant_demo_backend/semant_demo/config.py
@@ -100,7 +100,7 @@ class Config:
             },
             "qwen3_embedding_0_6b": {
                 "provider": EmbeddingProvider.ollama.value,
-                "model": os.getenv("OLLAMA_QWEN3_EMBEDDING_0_6B_MODEL", "qwen3-embedding-0.6b:latest"),
+                "model": os.getenv("OLLAMA_QWEN3_EMBEDDING_0_6B_MODEL", "qwen3-embedding:0.6b"),
                 "base_url": self.OLLAMA_URLS[0],
             },
         }

--- a/semant_demo_backend/semant_demo/embedding_router.py
+++ b/semant_demo_backend/semant_demo/embedding_router.py
@@ -1,0 +1,77 @@
+from openai import AsyncOpenAI
+from ollama import AsyncClient
+
+from semant_demo.config import config
+from semant_demo.schemas import EmbeddingProvider
+
+
+def _resolve_embedding_config(vector_name: str | None) -> tuple[str, dict[str, str]]:
+    resolved_vector = config.resolve_chunk_vector(vector_name)
+    embedding_config = config.get_chunk_vector_embedding_config(resolved_vector)
+    return resolved_vector, embedding_config
+
+
+async def _get_ollama_embeddings(texts: list[str], model: str, base_url: str) -> list[list[float]]:
+    client = AsyncClient(host=base_url)
+    try:
+        response = await client.embed(model=model, input=texts)
+        embeddings = response.get("embeddings") if isinstance(response, dict) else response.embeddings
+    except AttributeError:
+        embeddings = []
+        for text in texts:
+            response = await client.embeddings(model=model, prompt=text)
+            embedding = response.get("embedding") if isinstance(response, dict) else response.embedding
+            embeddings.append(embedding)
+
+    if not embeddings:
+        raise RuntimeError(f"Ollama returned no embeddings for model '{model}'")
+    return embeddings
+
+
+async def _get_openrouter_embeddings(
+    texts: list[str],
+    model: str,
+    base_url: str,
+    api_key: str | None,
+) -> list[list[float]]:
+    if not api_key:
+        raise RuntimeError("OpenRouter embedding API key is not configured")
+
+    client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+    response = await client.embeddings.create(model=model, input=texts)
+    return [item.embedding for item in response.data]
+
+
+async def get_documents_embeddings(
+    texts: list[str],
+    vector_name: str | None = None,
+) -> list[list[float]]:
+    resolved_vector, embedding_config = _resolve_embedding_config(vector_name)
+    provider = embedding_config.get("provider")
+    model = embedding_config.get("model")
+    base_url = embedding_config.get("base_url")
+
+    if not model or not base_url:
+        raise RuntimeError(f"Embedding config for vector '{resolved_vector}' must define model and base_url")
+
+    if provider == EmbeddingProvider.ollama.value:
+        return await _get_ollama_embeddings(texts, model=model, base_url=base_url)
+    if provider == EmbeddingProvider.openrouter.value:
+        return await _get_openrouter_embeddings(
+            texts,
+            model=model,
+            base_url=base_url,
+            api_key=embedding_config.get("api_key"),
+        )
+
+    raise RuntimeError(f"Unsupported embedding provider '{provider}' for vector '{resolved_vector}'")
+
+
+async def get_query_embedding(query: str, vector_name: str | None = None) -> list[float]:
+    embeddings = await get_documents_embeddings([query], vector_name=vector_name)
+    return embeddings[0]
+
+
+async def get_hyde_document_embedding(text: str, vector_name: str | None = None) -> list[float]:
+    embeddings = await get_documents_embeddings([text], vector_name=vector_name)
+    return embeddings[0]

--- a/semant_demo_backend/semant_demo/rag/adaptive_rag.py
+++ b/semant_demo_backend/semant_demo/rag/adaptive_rag.py
@@ -246,6 +246,7 @@ class AdaptiveRagGenerator(BaseRag):
                 type = self.search_type,
                 hybrid_search_alpha = self.alpha,
                 limit = 5 if state.get("retrieval_iteration_counter", 0) == 0 else self.chunk_limit,
+                vector_name = state.get("vector_name", self.vector_name),
                 min_year = metadata.get("min_year"),
                 max_year = metadata.get("max_year"),
                 min_date = metadata.get("min_date"),
@@ -657,6 +658,7 @@ class AdaptiveRagGenerator(BaseRag):
             intial_state_values = {
                 "original_question" : request.question,
                 "question" : request.question,
+                "vector_name": request.rag_search.vector_name or self.vector_name,
                 "queries" : [],
                 "context_sufficient" : False,
                 "history": history_preprocessed,

--- a/semant_demo_backend/semant_demo/rag/adaptive_rag_og.py
+++ b/semant_demo_backend/semant_demo/rag/adaptive_rag_og.py
@@ -242,6 +242,7 @@ class AdaptiveRagGeneratorOg(BaseRag):
                 type = self.search_type,
                 hybrid_search_alpha = self.alpha,
                 limit = self.chunk_limit,
+                vector_name = state.get("vector_name", self.vector_name),
                 min_year = metadata.get("min_year"),
                 max_year = metadata.get("max_year"),
                 min_date = metadata.get("min_date"),
@@ -611,6 +612,7 @@ class AdaptiveRagGeneratorOg(BaseRag):
             intial_state_values = {
                 "original_question" : request.question,
                 "question" : request.question,
+                "vector_name": request.rag_search.vector_name or self.vector_name,
                 "queries" : [],
                 "context_sufficient" : False,
                 "history": history_preprocessed,

--- a/semant_demo_backend/semant_demo/rag/agentic_rag.py
+++ b/semant_demo_backend/semant_demo/rag/agentic_rag.py
@@ -175,11 +175,19 @@ class LangchainLLM:
 
 
 class WeaviateToolWrapper:
-    def __init__(self, searcher: WeaviateAbstraction, rag_search: RagSearch, alpha: float, chunk_limit: int):
+    def __init__(
+        self,
+        searcher: WeaviateAbstraction,
+        rag_search: RagSearch,
+        alpha: float,
+        chunk_limit: int,
+        vector_name: str,
+    ):
         self.searcher = searcher
         self.rag_search = rag_search
         self.alpha = alpha
         self.chunk_limit = chunk_limit
+        self.vector_name = vector_name
         self.last_results = None 
 
     async def _call_weaviate_search(self, rag_search: RagSearch,  type: SearchType) -> SearchResponse:
@@ -189,6 +197,7 @@ class WeaviateToolWrapper:
             type = type,
             hybrid_search_alpha = self.alpha,
             limit = self.chunk_limit,
+            vector_name = rag_search.vector_name or self.vector_name,
             min_year = rag_search.min_year,
             max_year = rag_search.max_year,
             min_date = rag_search.min_date,
@@ -346,7 +355,8 @@ class xmartiAgentRag(BaseRag):
             searcher=searcher,
             rag_search=request.rag_search,
             alpha=self.alpha,
-            chunk_limit=self.chunk_limit
+            chunk_limit=self.chunk_limit,
+            vector_name=request.rag_search.vector_name or self.vector_name
         )
         assess_tool = AssessRetrievalQualityTool(self.model_name, self._client, self.assess_prompt)
         expand_tool = ExpandQueryTool(self.model_name, self._client, self.expand_prompt)

--- a/semant_demo_backend/semant_demo/rag/incremental_rag.py
+++ b/semant_demo_backend/semant_demo/rag/incremental_rag.py
@@ -269,6 +269,7 @@ class IncrementalAdaptiveRagGenerator(BaseRag):
                     type = self.search_type,
                     hybrid_search_alpha = alpha,
                     limit = limit,
+                    vector_name = state.get("vector_name", self.vector_name),
                     min_year = metadata.get("min_year"),
                     max_year = metadata.get("max_year"),
                     min_date = metadata.get("min_date"),
@@ -652,6 +653,7 @@ class IncrementalAdaptiveRagGenerator(BaseRag):
             intial_state_values = {
                 "original_question" : request.question,
                 "question" : request.question,
+                "vector_name": request.rag_search.vector_name or self.vector_name,
                 "queries" : [],
                 "context_sufficient" : False,
                 "history": history_preprocessed,

--- a/semant_demo_backend/semant_demo/rag/rag_factory.py
+++ b/semant_demo_backend/semant_demo/rag/rag_factory.py
@@ -8,6 +8,7 @@ class BaseRag:
    def __init__(self, global_config, param_config):
        self.global_config = global_config
        self.param_config = param_config
+       self.vector_name = global_config.resolve_chunk_vector(param_config.get("vector_name"))
        
    async def rag_request(self, request: RagRequest, searcher) -> RagResponse:
         raise NotImplementedError("Method \"rag_request\" is not implemented.")

--- a/semant_demo_backend/semant_demo/rag/rag_generator.py
+++ b/semant_demo_backend/semant_demo/rag/rag_generator.py
@@ -129,6 +129,7 @@ class RagGenerator(BaseRag):
             type = self.search_type,
             hybrid_search_alpha = self.alpha,
             limit = self.chunk_limit,
+            vector_name = rag_search.vector_name or self.vector_name,
             min_year = rag_search.min_year,
             max_year = rag_search.max_year,
             min_date = rag_search.min_date,

--- a/semant_demo_backend/semant_demo/schemas.py
+++ b/semant_demo_backend/semant_demo/schemas.py
@@ -23,6 +23,11 @@ class APIType(str, Enum):
     metacentrum = "METACENTRUM"
 
 
+class EmbeddingProvider(str, Enum):
+    ollama = "OLLAMA"
+    openrouter = "OPENROUTER"
+
+
 class SummaryRequestBase(BaseModel):
     search_title_generate: bool = True
     search_title_prompt: str | None = None
@@ -49,6 +54,7 @@ class SearchRequest(SummaryRequestBase):
     user_collection_id: str | None = None
     type: SearchType = SearchType.hybrid
     hybrid_search_alpha: float = 0.5
+    vector_name: str | None = None
     search_llm_filter: bool = False
 
     min_year: int | None = None
@@ -169,6 +175,7 @@ class RagSearch(BaseModel):
     alpha: float = 0.5
     limit: int = 10
     search_query: str | None = None
+    vector_name: str | None = None
     min_year: int | None = None
     max_year: int | None = None
     min_date: datetime | None = None
@@ -218,6 +225,7 @@ class AdaptiveRagState(TypedDict):
     language: str | None  # ces, des, eng, ...
     question: str
     original_question: str
+    vector_name: str
     queries: list[str]
     context_sufficient: bool
     history: list[Any]

--- a/semant_demo_backend/semant_demo/weaviate_client.py
+++ b/semant_demo_backend/semant_demo/weaviate_client.py
@@ -14,13 +14,14 @@ from weaviate.classes.query import Filter, Sort, QueryReference
 import logging
 
 class WeaviateSearch:
-    def __init__(self, client: WeaviateAsyncClient):
+    def __init__(self, client: WeaviateAsyncClient, collectionNames):
         self.client = client
+        self.collectionNames = collectionNames
         # collections.get() is synchronous, no await needed
-        self.chunk_col = self.client.collections.get("Chunks_test")
+        self.chunk_col = self.client.collections.get(collectionNames.chunks_collection_name)
 
         try:
-            self.tagspan_col = self.client.collections.get("Span_test")
+            self.tagspan_col = self.client.collections.get(collectionNames.span_collection_name)
         except Exception:
             self.tagspan_col = None
     
@@ -37,7 +38,7 @@ class WeaviateSearch:
             logging.error("Weaviate is not ready.")
             await async_client.close()
             exit(-1)
-        return cls(async_client)
+        return cls(async_client, config.collectionNames)
 
     async def close(self):
         await self.client.close()  # :contentReference[oaicite:2]{index=2}
@@ -48,7 +49,7 @@ class WeaviateClient(WeaviateSearch):
         Retrieves all collections for given user
         """
         usercollection_collection = self.client.collections.get(
-            "UserCollection")
+            self.collectionNames.user_collection_name)
 
         filters = (
             Filter.by_property("user_id").equal(user_id)
@@ -76,7 +77,7 @@ class WeaviateClient(WeaviateSearch):
         """
 
         usercollection_collection = self.client.collections.get(
-            "UserCollection")
+            self.collectionNames.user_collection_name)
         response = await usercollection_collection.query.fetch_object_by_id(collection_id)
         if response is None:
             return None
@@ -101,7 +102,7 @@ class WeaviateClient(WeaviateSearch):
             return None
 
         # Compute documents count
-        documents_collection = self.client.collections.get("Documents")
+        documents_collection = self.client.collections.get(self.collectionNames.document_collection_name)
         documents_filters = (
             Filter.by_ref("collection").by_id().equal(collection_id)
         )
@@ -117,7 +118,7 @@ class WeaviateClient(WeaviateSearch):
             Filter.by_ref("userCollection").by_id().equal(collection_id)
         )
 
-        chunks_collection = self.client.collections.get("Chunks")
+        chunks_collection = self.client.collections.get(self.collectionNames.chunks_collection_name)
         chunks_count_response = await chunks_collection.aggregate.over_all(
             total_count=True,
             filters=chunks_filters
@@ -125,7 +126,7 @@ class WeaviateClient(WeaviateSearch):
         chunks_count = chunks_count_response.total_count or 0
 
         # Compute tags count
-        tags_collection = self.client.collections.get("Tag")
+        tags_collection = self.client.collections.get(self.collectionNames.tag_collection_name)
         tags_filters = (
             Filter.by_ref("userCollection").by_id().equal(collection_id)
         )
@@ -139,7 +140,7 @@ class WeaviateClient(WeaviateSearch):
         # One annotation = one span object.
         # Span belongs to selected collection if linked chunk OR linked tag belongs to that collection.
 
-        spans_collection = self.client.collections.get("Span_test")
+        spans_collection = self.client.collections.get(self.collectionNames.span_collection_name)
 
         spans_filters = (
             Filter.by_ref("text_chunk").by_ref(
@@ -168,7 +169,7 @@ class WeaviateClient(WeaviateSearch):
         Creates new collection and returns its id
         """
         usercollection_collection = self.client.collections.get(
-            "UserCollection")
+            self.collectionNames.user_collection_name)
         now = datetime.now(timezone.utc)
 
         uuid = await usercollection_collection.data.insert(
@@ -188,7 +189,7 @@ class WeaviateClient(WeaviateSearch):
         Updates collection with given id, raises exception if collection with given id does not exist
         """
         usercollection_collection = self.client.collections.get(
-            "UserCollection")
+            self.collectionNames.user_collection_name)
         now = datetime.now(timezone.utc)
 
         # PATCH semantics: update only fields that were actually sent by the client.
@@ -206,11 +207,11 @@ class WeaviateClient(WeaviateSearch):
         Before deleting the collection object itself, remove references to it
         from chunks, documents, and tags.
         """
-        documents_collection = self.client.collections.get("Documents")
-        chunks_collection = self.client.collections.get("Chunks")
-        tags_collection = self.client.collections.get("Tag")
+        documents_collection = self.client.collections.get(self.collectionNames.document_collection_name)
+        chunks_collection = self.client.collections.get(self.collectionNames.chunks_collection_name)
+        tags_collection = self.client.collections.get(self.collectionNames.tag_collection_name)
         usercollection_collection = self.client.collections.get(
-            "UserCollection")
+            self.collectionNames.user_collection_name)
 
         page_size = 100
 
@@ -256,7 +257,7 @@ class WeaviateClient(WeaviateSearch):
         """
         Retrieves document by its id, returns None if document with given id does not exist
         """
-        document_collection = self.client.collections.get("Documents")
+        document_collection = self.client.collections.get(self.collectionNames.document_collection_name)
         response = await document_collection.query.fetch_object_by_id(document_id)
         if response is None:
             return None
@@ -270,7 +271,7 @@ class WeaviateClient(WeaviateSearch):
         """
         Retrieves all documents - optionally can be filtered by collection id
         """
-        document_collection = self.client.collections.get("Documents")
+        document_collection = self.client.collections.get(self.collectionNames.document_collection_name)
         filters = None
         if collection_id is not None:
             filters = (
@@ -303,7 +304,7 @@ class WeaviateClient(WeaviateSearch):
         """
         Retrieves documents in pages with optional filters for browsing large datasets.
         """
-        document_collection = self.client.collections.get("Documents")
+        document_collection = self.client.collections.get(self.collectionNames.document_collection_name)
         filters = None
 
         def append_filter(current_filter, new_filter):
@@ -369,7 +370,7 @@ class WeaviateClient(WeaviateSearch):
         """
         Retrieves all tags - optionally filtered by collection id.
         """
-        tag_collection = self.client.collections.get("Tag")
+        tag_collection = self.client.collections.get(self.collectionNames.tag_collection_name)
         filters = None
         if collection_id is not None:
             filters = Filter.by_ref("userCollection").by_id().equal(collection_id)
@@ -405,7 +406,7 @@ class WeaviateClient(WeaviateSearch):
         Retrieves one tag by id, scoped to a collection.
         Returns None if not found or if the tag is not linked to the collection.
         """
-        tag_collection = self.client.collections.get("Tag")
+        tag_collection = self.client.collections.get(self.collectionNames.tag_collection_name)
         response = await tag_collection.query.fetch_object_by_id(
             tag_uuid,
             return_references=[QueryReference(link_on="userCollection")],
@@ -439,7 +440,7 @@ class WeaviateClient(WeaviateSearch):
         if collection is None:
             raise ValueError("Collection not found")
 
-        tag_collection = self.client.collections.get("Tag")
+        tag_collection = self.client.collections.get(self.collectionNames.tag_collection_name)
 
         filters = Filter.by_ref("userCollection").by_id().equal(collection_id)
         existing = await tag_collection.query.fetch_objects(
@@ -508,9 +509,9 @@ class WeaviateClient(WeaviateSearch):
         """
         Deletes a tag after removing every reference to it from Span and Chunk collections.
         """
-        tag_collection = self.client.collections.get("Tag")
-        span_collection = self.client.collections.get("Span_test")
-        chunk_collection = self.client.collections.get("Chunks")
+        tag_collection = self.client.collections.get(self.collectionNames.tag_collection_name)
+        span_collection = self.client.collections.get(self.collectionNames.span_collection_name)
+        chunk_collection = self.client.collections.get(self.collectionNames.chunks_collection_name)
 
         tag_response = await tag_collection.query.fetch_object_by_id(
             tag_uuid,
@@ -587,7 +588,7 @@ class WeaviateClient(WeaviateSearch):
         """
         Updates an existing tag in a collection.
         """
-        tag_collection = self.client.collections.get("Tag")
+        tag_collection = self.client.collections.get(self.collectionNames.tag_collection_name)
 
         tag_response = await tag_collection.query.fetch_object_by_id(
             tag_uuid,
@@ -632,8 +633,8 @@ class WeaviateClient(WeaviateSearch):
         """
         Adds a document to a collection and also links all its chunks to that collection.
         """
-        document_collection = self.client.collections.get("Documents")
-        chunks_collection = self.client.collections.get("Chunks")
+        document_collection = self.client.collections.get(self.collectionNames.document_collection_name)
+        chunks_collection = self.client.collections.get(self.collectionNames.chunks_collection_name)
         try:
             matched_chunks = 0
             already_linked_chunks = 0
@@ -704,8 +705,8 @@ class WeaviateClient(WeaviateSearch):
         """
         Removes a document from a collection by deleting the reference between them.
         """
-        document_collection = self.client.collections.get("Documents")
-        chunks_collection = self.client.collections.get("Chunks")
+        document_collection = self.client.collections.get(self.collectionNames.document_collection_name)
+        chunks_collection = self.client.collections.get(self.collectionNames.chunks_collection_name)
         try:
             await document_collection.data.reference_delete(
                 from_uuid=document_id,

--- a/semant_demo_backend/semant_demo/weaviate_utils/text_chunk.py
+++ b/semant_demo_backend/semant_demo/weaviate_utils/text_chunk.py
@@ -29,7 +29,7 @@ from weaviate.classes.query import Filter
 
 from semant_demo import schemas
 from semant_demo.config import Config
-from semant_demo.gemma_embedding import get_query_embedding, get_hyde_document_embedding
+from semant_demo.embedding_router import get_query_embedding, get_hyde_document_embedding
 from weaviate.classes.query import QueryReference
 from semant_demo.config import config
 
@@ -38,12 +38,18 @@ import logging
 from semant_demo.weaviate_utils.helpers import WeaviateHelpers
 
 class TextChunk():
-    def __init__(self, client: WeaviateAsyncClient, collectionNames: schemas.CollectionNames):
+    def __init__(
+        self,
+        client: WeaviateAsyncClient,
+        collectionNames: schemas.CollectionNames,
+        vector_name: str | None = None,
+    ):
         self.client = client
         self.helpers = WeaviateHelpers(client, collectionNames)
         self.chunk_collection = self.client.collections.get(collectionNames.chunks_collection_name)
         self.span_collection = self.client.collections.get(collectionNames.span_collection_name)
         self.user_collection = self.client.collections.get(collectionNames.user_collection_name)
+        self.default_vector = config.resolve_chunk_vector(vector_name)
 
     #######
     # API #
@@ -104,18 +110,22 @@ class TextChunk():
                 "section", "region", "id_code"
         ]
 
+        target_vector = config.resolve_chunk_vector(search_request.vector_name or self.default_vector)
+        search_request.vector_name = target_vector
+
         t1 = time()
         if search_request.type == schemas.SearchType.hybrid:
             if search_request.is_hyde == False:
-                q_vector = await get_query_embedding(search_request.query)
+                q_vector = await get_query_embedding(search_request.query, vector_name=target_vector)
             else:
-                q_vector = await get_hyde_document_embedding(search_request.query)
+                q_vector = await get_hyde_document_embedding(search_request.query, vector_name=target_vector)
 
             # Execute hybrid search
             result = await self.chunk_collection.query.hybrid(
                 query=search_request.query,
                 alpha=search_request.hybrid_search_alpha,
                 vector=q_vector,
+                target_vector=target_vector,
                 limit=search_request.limit,
                 filters=combined_filter,
                 return_references=[QueryReference(link_on="document", return_properties=document_properties_to_return),
@@ -149,12 +159,13 @@ class TextChunk():
             )
         elif search_request.type == schemas.SearchType.vector:
             if search_request.is_hyde == False:
-                q_vector = await get_query_embedding(search_request.query)
+                q_vector = await get_query_embedding(search_request.query, vector_name=target_vector)
             else:
-                q_vector = await get_hyde_document_embedding(search_request.query)
+                q_vector = await get_hyde_document_embedding(search_request.query, vector_name=target_vector)
 
             result = await self.chunk_collection.query.near_vector(
                 near_vector=q_vector,
+                target_vector=target_vector,
                 limit=search_request.limit,
                 filters=combined_filter,
                 return_references=[QueryReference(link_on="document", return_properties=document_properties_to_return),
@@ -177,6 +188,7 @@ class TextChunk():
         results: list[schemas.TextChunkWithDocument] = []
         log_entry = (
             f"Top {len(result.objects)} results for “{search_request.query}”. "
+            f"Vector: {search_request.vector_name}. "
             f"Retrieved in {search_time:.2f} seconds:"
         )
         logging.info(log_entry)

--- a/semant_demo_backend/semant_demo/weaviate_utils/weaviate_abstraction.py
+++ b/semant_demo_backend/semant_demo/weaviate_utils/weaviate_abstraction.py
@@ -7,7 +7,6 @@ from weaviate.classes.query import Filter
 
 from semant_demo import schemas
 from semant_demo.config import Config
-from semant_demo.gemma_embedding import get_query_embedding, get_hyde_document_embedding
 from weaviate.classes.query import QueryReference
 from semant_demo.config import config
 
@@ -35,7 +34,12 @@ from semant_demo.weaviate_utils.text_chunk import TextChunk
 from semant_demo.weaviate_utils.user_collection import UserCollection
 
 class WeaviateAbstraction():
-    def __init__(self, client: WeaviateAsyncClient, collectionNames: schemas.CollectionNames):
+    def __init__(
+        self,
+        client: WeaviateAsyncClient,
+        collectionNames: schemas.CollectionNames,
+        vector_name: str | None = None,
+    ):
         self.client = client
         self.collectionNames = collectionNames
 
@@ -43,7 +47,7 @@ class WeaviateAbstraction():
         self.document = Document(client=client, collectionNames=collectionNames)
         self.span = Span(client=client, collectionNames=collectionNames)
         self.tag = Tag(client=client, collectionNames=collectionNames)
-        self.textChunk = TextChunk(client=client, collectionNames=collectionNames)
+        self.textChunk = TextChunk(client=client, collectionNames=collectionNames, vector_name=vector_name)
         self.userCollection = UserCollection(client=client, collectionNames=collectionNames) 
 
     @classmethod
@@ -59,7 +63,7 @@ class WeaviateAbstraction():
             logging.error("Weaviate is not ready.")
             await async_client.close()
             exit(-1)
-        return cls(async_client, config.collectionNames)
+        return cls(async_client, config.collectionNames, vector_name=config.DEFAULT_CHUNK_VECTOR)
 
     async def close(self):
         await self.client.close()  # :contentReference[oaicite:2]{index=2}


### PR DESCRIPTION
## Summary

This PR adds backend support for searching chunk collections that use Weaviate named vectors, including the new `Chunks_test_multivector` collection.

The change introduces config-driven vector selection so RAG/search can use a default named vector from backend config, while still allowing request-level overrides. It also adds an embedding router that maps named vectors to the correct embedding provider, currently supporting Ollama and OpenRouter-compatible embeddings.

The previous backend search path assumed a single embedding flow and did not pass `target_vector` to Weaviate. It also hardcoded the chunk collection in several runtime paths.

## Main Changes

- Add `vector_name` to search and RAG request schemas.
- Add config values for:
  - `CHUNKS_COLLECTION_NAME`
  - `DEFAULT_CHUNK_VECTOR`
  - `AVAILABLE_CHUNK_VECTORS`
  - `CHUNK_VECTOR_EMBEDDINGS`
- Add a new embedding router for named-vector embedding generation.
- Pass `target_vector` to Weaviate `hybrid` and `near_vector` queries.
- Make RAG classes fall back to the configured default vector when no vector is passed.
- Update runtime chunk collection usage to use configured collection names.
- Changed hardcoded collection names in weaviate_client.py

## Important requirements

For full backend functionality, `Chunks_test_multivector` must expose the same reference properties expected by the search layer:

- `document`
- `userCollection`
- `automaticTag`
- `positiveTag`
- `negativeTag`

Currently, `Chunks_test_multivector` has no references. Without these references, search will fail when the backend asks Weaviate to return `document`, `automaticTag`, or `positiveTag`.

fix: add/migrate references onto `Chunks_test_multivector` so document metadata, year filters, user collections, and tag filters continue to work.


**Pull models to ollama, mainly**  `nomic-embed-text-v2-moe:latest` and `qwen3-embedding:0.6b` 

